### PR TITLE
Add Orb assistant skeleton

### DIFF
--- a/orb/App.js
+++ b/orb/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Orb Assistant</Text>
+      <Text>Merhaba! Buradan uygulamanızı geliştirmeye başlayabilirsiniz.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12
+  }
+});

--- a/orb/README.md
+++ b/orb/README.md
@@ -1,0 +1,24 @@
+# Orb - Kişisel AI Yönetici Asistan Uygulaması
+
+Orb, girişimciler ve üretken bireyler için geliştirilen GPT-4.1 destekli mobil
+asistan uygulamasıdır. Uygulama, sesli ve yazılı olarak etkileşime geçilebilen
+bir "orb" arayüzü sunar ve kullanıcıların günlük hedeflerini takip etmelerine,
+zamanlarını verimli kullanmalarına yardımcı olur.
+
+## Özellikler
+- **Kişisel bağlam**: Kullanıcı hedefleri ve motivasyonunu hafızada tutar.
+- **Görev ve Takvim Senkronizasyonu**: Google Calendar API entegrasyonu ile
+görev hatırlatmaları.
+- **Günlük Diyalog Şablonları**: Sabah, öğlen ve akşam motivasyon soruları.
+- **Bildirim Sistemi**: Push bildirimleri ve dinamik hatırlatmalar.
+- **Premium Model**: 7 gün ücretsiz kullanım ardından abonelik seçeneği.
+
+## Teknik Mimarisi
+- Mobil: **React Native** (örn. Expo)
+- Backend: **Supabase**
+- AI: **OpenAI GPT-4.1 Assistants API**
+- Kimlik Doğrulama: **Firebase Auth**
+- Bildirimler: **OneSignal**
+
+Uygulamanın temel bileşenleri `App.js` içinde örnek bir orb arayüzü ile
+başlatılmıştır. Geliştirmeye buradan devam edebilirsiniz.

--- a/orb/package.json
+++ b/orb/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "orb",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'Run expo start here'",
+    "test": "echo 'No tests defined'"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  }
+}


### PR DESCRIPTION
## Summary
- start a new `orb` directory for the Orb personal AI assistant app
- document project features and architecture in `orb/README.md`
- include minimal React Native example in `orb/App.js`
- add `package.json` with placeholder scripts

## Testing
- `npm test` in `orb`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f4e7b057c832c9fb55a126b822d4a